### PR TITLE
Included regex to parse symbols and words

### DIFF
--- a/structures/blocks.go
+++ b/structures/blocks.go
@@ -42,6 +42,7 @@ func (b *Block) CreateTokens() {
 func (b *Block) blockWordMaps() (map[string]int, map[string][]int) { //Helper function for CreateTokens()
 
 	pythonKeywords := [35]string{"False", "await", "else", "import", "pass", "None", "break", "except", "in", "raise", "True", "class", "finally", "is", "return", "and", "continue", "for", "lambda", "try", "as", "def", "from", "nonlocal", "while", "assert", "del", "global", "not", "with", "async", "elif", "if", "or", "yield"}
+	pythonOps := [34]string{"+", "-", "*", "/", "//", "%", "**", "==", "!=", ">", "<", ">=", "<=", "=", "+=", "-=", "*=", "/=", "//=", "%=", "**=", "&=", "|=", "^=", ">>=", "<<=", "&", "|", "^", "~", "<<", ">>"}
 
 	wordCount := make(map[string]int)   // Map to store words and their counts (word -> count)
 	wordLines := make(map[string][]int) // Map to store on which lines a word appears (word -> lines)
@@ -56,13 +57,20 @@ func (b *Block) blockWordMaps() (map[string]int, map[string][]int) { //Helper fu
 
 			for _, w := range words {
 				isKeyword := false
-				for _, p := range pythonKeywords { //Quick loop to check if the word is a Python keyword, in which case it should be ignored
+				isPythonOp := false
+				for _, p := range pythonKeywords { //Ignores Python Keywords
 					if w == p {
 						isKeyword = true
 						break
 					}
 				}
-				if !isKeyword {
+				for _, op := range pythonOps { //Ignores Python Math/Logical operators
+					if w == op {
+						isPythonOp = true
+						break
+					}
+				}
+				if !isKeyword && !isPythonOp {
 					wordCount[w]++                                 //Increase word count for this block
 					wordLines[w] = append(wordLines[w], lineNum+1) // +1 because we don't have line 0 in most IDEs
 				}

--- a/structures/blocks.go
+++ b/structures/blocks.go
@@ -1,6 +1,7 @@
 package structures
 
 import (
+	"regexp"
 	"strings"
 )
 
@@ -41,8 +42,11 @@ func (b *Block) CreateTokens() {
 
 func (b *Block) blockWordMaps() (map[string]int, map[string][]int) { //Helper function for CreateTokens()
 
+	var re = regexp.MustCompile(`[A-Za-z_][A-Za-z_0-9]*|[^\sA-Za-z_0-9]`) //General regex to separate words and symbols WITHOUT whitespaces
+
 	pythonKeywords := [35]string{"False", "await", "else", "import", "pass", "None", "break", "except", "in", "raise", "True", "class", "finally", "is", "return", "and", "continue", "for", "lambda", "try", "as", "def", "from", "nonlocal", "while", "assert", "del", "global", "not", "with", "async", "elif", "if", "or", "yield"}
-	pythonOps := [34]string{"+", "-", "*", "/", "//", "%", "**", "==", "!=", ">", "<", ">=", "<=", "=", "+=", "-=", "*=", "/=", "//=", "%=", "**=", "&=", "|=", "^=", ">>=", "<<=", "&", "|", "^", "~", "<<", ">>"}
+	pythonOps := [41]string{"'", "(", ")", "{", "}", "[", "]", "+", "-", "*", "/", "//", "%", "**", "==", "!=", ">", "<", ">=", "<=", "=", "+=", "-=", "*=", "/=", "//=", "%=", "**=", "&=", "|=", "^=", ">>=", "<<=", "&", "|", "^", "~", "<<", ">>"}
+	//Note that pythonOps includes things like (), {} and [] at this moment
 
 	wordCount := make(map[string]int)   // Map to store words and their counts (word -> count)
 	wordLines := make(map[string][]int) // Map to store on which lines a word appears (word -> lines)
@@ -53,7 +57,7 @@ func (b *Block) blockWordMaps() (map[string]int, map[string][]int) { //Helper fu
 		trimmed := strings.TrimSpace(line)    //Removes whitespace before "#" - we'll consider it for the indentation in another function
 		if !strings.HasPrefix(trimmed, "#") { //Completely ignores line if it starts with # (it is a comment!)
 
-			words := strings.Fields(line)
+			words := re.FindAllString(line, -1) //Get words and symbols on line WITHOUT whitespaces
 
 			for _, w := range words {
 				isKeyword := false


### PR DESCRIPTION
The regex essentially selects everything BUT whitespaces. It's useful, however, to avoid problems detecting and separating symbols regardless of spaces. For example:

(lorem ipsum)
( lorem ipsum )

Both should return "(", "lorem", "ipsum", ")", which should allow us to ignore the parenthesis (in this case) without problems (for now :P)