### PR TITLE
Add regex and code to ignore strings on the Python code

### DIFF
--- a/structures/blocks.go
+++ b/structures/blocks.go
@@ -42,7 +42,8 @@ func (b *Block) CreateTokens() {
 
 func (b *Block) blockWordMaps() (map[string]int, map[string][]int) { //Helper function for CreateTokens()
 
-	var re = regexp.MustCompile(`[A-Za-z_][A-Za-z_0-9]*|[^\sA-Za-z_0-9]`) //General regex to separate words and symbols WITHOUT whitespaces
+	var genRe = regexp.MustCompile(`[A-Za-z_][A-Za-z_0-9]*|[^\sA-Za-z_0-9]`) //General regex to separate words and symbols WITHOUT whitespaces
+	var betweenQuotes = regexp.MustCompile(`"[^"]*"`)                        //Selects strings - stuff between quotes "" - so we may ignore them
 
 	pythonKeywords := [35]string{"False", "await", "else", "import", "pass", "None", "break", "except", "in", "raise", "True", "class", "finally", "is", "return", "and", "continue", "for", "lambda", "try", "as", "def", "from", "nonlocal", "while", "assert", "del", "global", "not", "with", "async", "elif", "if", "or", "yield"}
 	pythonOps := [41]string{"'", "(", ")", "{", "}", "[", "]", "+", "-", "*", "/", "//", "%", "**", "==", "!=", ">", "<", ">=", "<=", "=", "+=", "-=", "*=", "/=", "//=", "%=", "**=", "&=", "|=", "^=", ">>=", "<<=", "&", "|", "^", "~", "<<", ">>"}
@@ -57,7 +58,8 @@ func (b *Block) blockWordMaps() (map[string]int, map[string][]int) { //Helper fu
 		trimmed := strings.TrimSpace(line)    //Removes whitespace before "#" - we'll consider it for the indentation in another function
 		if !strings.HasPrefix(trimmed, "#") { //Completely ignores line if it starts with # (it is a comment!)
 
-			words := re.FindAllString(line, -1) //Get words and symbols on line WITHOUT whitespaces
+			removeInQuotes := betweenQuotes.ReplaceAllString(trimmed, "") //Ignores strings (anything between quotes "")
+			words := genRe.FindAllString(removeInQuotes, -1)              //Get words and symbols on line WITHOUT whitespaces
 
 			for _, w := range words {
 				isKeyword := false


### PR DESCRIPTION
Added another regex to select strings, which we can use to ignore them BEFORE separating symbols and words through the rest of the Python code.